### PR TITLE
Demo app as example

### DIFF
--- a/User_guide.md
+++ b/User_guide.md
@@ -24,7 +24,9 @@ As prerequisites, you need to have the following tools set up:
 This section describes the steps for creating and starting an SDK docker container which supports building an application based on EB corbos Linux (EBcL).
 
 ### Build and start SDK docker container
-Start VS Code and open a remote connection to the EC2 instance.
+Start VS Code.
+
+If the EB corbos Linux SDK workspace has been downloaded to a remote server open a remote connection to this server.
 
 Open the workspace **/home/ubuntu/EBcL/ebcl_sdk_1-0-0.code-workspace**.
 
@@ -143,10 +145,10 @@ Get the report archive file at the SDK terminal by running the command
 scp -P 2222 root@127.0.0.1:/<application name>_report.tar.gz .
 ```
 
-In order to provide this report archive file for the certification please retrieve it via scp from outside the EC2 instance.
+For the certification please provide this report archive file.
 
 ## Demo application
-There are provided the demo applications **hello-world** and **myjsonapp** located at the sub-folder **demo**.
+There are provided the demo applications **hello-world** and **myjsonapp** located at the sub-folder **workspace/demo**.
 
 ### Build demo application
 In order to build one of these demo applications remove the contents of the folder **app** if not empty, copy the contents of the related sub-folder to the folder **app** inside the SDK terminal and follow the description given above for building an application.

--- a/User_guide.md
+++ b/User_guide.md
@@ -3,9 +3,9 @@ This document describes the creation and start of an SDK docker container
 which supports building an application based on EB corbos Linux (EBcL) 
 as well as the starting of a qemu image running the EBcL for x86_64 based on crinit.
 
-After installation and run of this application there can be called a script which is collecting some report data used for product compatibility testing.
+After installation and run of this application there can be called a script which is collecting some report data used for certification.
 
-## Preconditions
+## Setup development environment
 ### Download EB corbos Linux SDK workspace
 Download the EB corbos Linux SDK workspace which is published in the Elektrobit Github organization
 as a template repository (https://github.com/Elektrobit/ebcl_template/) at branch **PSS/main** by running the command
@@ -39,71 +39,97 @@ Then there is built and started the SDK docker container.
 For the following steps there have to be opened new terminals inside VS Code where the related commands have to be entered.
 
 ## Build EBcL image
-In order to build an EBcL qemu image for architecture amd64 based on crinit run the following commands at a terminal opened at the SDK (referred as SDK terminal):
+To build an EBcL image there are two scripts available for amd64 and aarch64 architecture. 
 ```bash
-box_build_image.sh workspace/images/qemu-crinit-amd64/appliance.kiwi 
-box_build_sysroot.sh workspace/images/qemu-crinit-amd64/appliance_sysroot.kiwi
+box_build_image.sh <image description>
+cross_build_image.sh <image description>
+```
+The image binary files and log files are stored at the folder **result_image/<image_name>**.
+
+For more information about creating EBcL images are available in the official EBcL user guide.
+
+## Build sysroot
+Before building applications a sysroot needs to be created. 
+```bash
+box_build_sysroot.sh <image description>
+cross_build_sysroot.sh <image description>
 ```
 
-The image binary files and log files are stored at the folder **result_image/ebcl_qemu_crinit_amd64**.
+## Building demo application
+### Note
+The following step-by-step guide provides an example how building an application can look like.
+As there are many different options available to build an application this example will not fit to all possible options.
 
-## Build application
-### Get all application sources needed for building the application
-In this step all application sources needed for building the application have to be made available inside the SDK docker container.
-
-Note that there have to be configured the related files at **/etc/apt/sources.list.d/** if the sources have to be retrieved via apt-get.
-
-The application sources have to be stored at the folder **app**.
-
-### Build application
-Adapt the variables **APP_NAME** and **APP_VERSION** in the file **workspace/gpg-keys/env.sh** for your application.
-
-Then run the following commands at the SDK terminal:
+The example consits of a small "Hello World"-C++ application called **myjsonapp** using json-cpp as an additional library.
+The result of the example is a Debian package which is added directly to the target image.
+The target image used for this example is **qemu-crinit-amd64**.
+### Step 1: Create sysroot
+To create the sysroot the script **box_build_sysroot.sh** is used by executing the command
+```bash
+box_build_sysroot.sh /build/workspace/images/qemu-crinit-amd64/appliance_sysroot.kiwi
+```
+in a terminal inside the Docker container.
+### Step 2: Build application and create Debian package
+To build the demo application copy the content of **/build/workspace/demo/myjsonapp** to **/build/app**.
+Then run the following commands in a terminal inside the SDK Docker container:
 ```bash
 prepare_deb_metadata.sh
 build_package.sh
 gen_sign_key.sh
 source /build/scripts/env.sh
 prepare_repo_config.sh
-serve_packages.sh&
 ```
+The generated output files are stored at the folders **/build/result_app** and **/tmp/myjsonapp**.
 
-The generated output files are stored at the folders **result_app** and **/tmp/\<your application\>**.
+### Step 3: Build the target image
+After building the Debian package can be added to the target image.
 
-### Configure application and rebuild image
-Add your application package at the file **workspace/images/qemu-crinit-amd64/appliance.kiwi** by adding the line
+As the Debian package is not part of any official repository it is needed to host a temporary local repository.
+To do this the script **serve_packages.sh** can be used which start hosting the local repository. 
+To not block the terminal the execution can be started as background task by executing the following line in a terminal inside the SDK Docker container:
 ```bash
-        <package name="<your application>"/> 
+serve_packages.sh &
 ```
-at the section **\<packages type="image"\>** with **\<your application\>** set to the value provided as **APP_NAME**.
+**_NOTE:_**  Do not terminate the script or terminal session until the target image is built!
 
-Then build the image including your application by running the following command at the SDK terminal:
+To add the built Debian package the following line needs to be added to /build/workspace/images/qemu-crinit-amd64/appliance_sysroot.kiwi in section **packages type="image"**:
 ```bash
-box_build_image.sh workspace/images/qemu-crinit-amd64/appliance.kiwi 
+<package name="my-json-app"/>
 ```
 
-## Start EBcL qemu image
-In order to start the EBcL image run the following command at a new terminal opened at the SDK (referred as target terminal):
+Next step is to build the image by executing the script box_build_sysroot.sh in a terminal inside the SDK Docker container.
 ```bash
-workspace/images/run_qemu_x86_64.sh result_image/qemu_crinit_amd64/qemu_crinit_amd64.x86_64-1.1.0-0.qcow2
+box_build_sysroot.sh /build/workspace/images/qemu-crinit-amd64/appliance_sysroot.kiwi
+```
+The result will be stored in /build/result_image/qemu-crinit-amd64. The image itself is the file qemu_crinit_amd64.x86_64-1.1.0-0.qcow2.
+
+### Step 4: Start the target image
+In order to start the target image in QEMU run the following command in a terminal inside the SDK Docker container:
+```bash
+/build/workspace/images/run_qemu_x86_64.sh \
+/build/result_image/qemu_crinit_amd64/qemu_crinit_amd64.x86_64-1.1.0-0.qcow2
 ```
 
-Note that the target can be stopped by running the command
+**_NOTE:_** The target image can be stopped by running the command
 ```bash
 crinit-ctl poweroff
 ```
 
-## Run application
-### Verify application start 
-At the target terminal ensure that the related crinit task configuration files are stored at **/etc/crinit/crinit.d/**.
+### Step 5: Run application
+#### crinit
+The used image for this example using crinit as init daemon.
+Every application which shall be controlled by crinit needs a task configuration file (stored in /etc/crinit/crinit.d/).
+More information about crinit can be found at https://github.com/Elektrobit/crinit.
+This example already have a task configuration file as part of the Debian package, therefore no action needed here.
 
+#### Verify application start 
 In order to verify the status of the application(s) run the command
 ```bash
 crinit-ctl list
 ```
+The status of the example application shall be **running** or **stopped** (in case application has already been finished).
 
-If the status is running (or done for applications finished already successfully) all the required tests can be executed.
-
+## Certification data
 ### System call information
 In order to provide system call information of your application run the following command at the target terminal:
 ```bash
@@ -146,18 +172,3 @@ scp -P 2222 root@127.0.0.1:/<application name>_report.tar.gz .
 ```
 
 For the certification please provide this report archive file.
-
-## Demo application
-There are provided the demo applications **hello-world** and **myjsonapp** located at the sub-folder **workspace/demo**.
-
-### Build demo application
-In order to build one of these demo applications remove the contents of the folder **app** if not empty, copy the contents of the related sub-folder to the folder **app** inside the SDK terminal and follow the description given above for building an application.
-
-### Run demo application
-Follow the steps mentioned above at run application and get report for the selected demo application.
-
-Note that the binary files created at target are:
-
-- **/usr/bin/hello-world** for demo application **hello-world**
-
-- **/usr/bin/MyJsonApp** for demo application **myjsonapp**

--- a/User_guide.md
+++ b/User_guide.md
@@ -3,7 +3,7 @@ This document describes the creation and start of an SDK docker container
 which supports building an application based on EB corbos Linux (EBcL) 
 as well as the starting of a qemu image running the EBcL for x86_64 based on crinit.
 
-After installation and run of this application there can be called a script which is collecting some report data used for certification.
+After installation and run of this application there can be called a script which is collecting some report data used for product compatibility testing.
 
 ## Preconditions
 ### Download EB corbos Linux SDK workspace


### PR DESCRIPTION
Changed the user guide towards making clear that the parts about how to build an application is only an example and will not be working for all possible use cases.
Remove the general build steps and added step-by-step guide to build the app/image and execute the demo app.
On top some small adaptions to other chapters.