### PR TITLE
qemu-crinit: Remove invalid config options

### DIFF
--- a/images/qemu-crinit-aarch64/root/etc/crinit/default.series
+++ b/images/qemu-crinit-aarch64/root/etc/crinit/default.series
@@ -1,4 +1,3 @@
 TASKDIR = /etc/crinit/crinit.d
 USE_SYSLOG = YES
 DEBUG = NO
-FILE_SIGS_NEEDED = NO

--- a/images/qemu-crinit-amd64/root/etc/crinit/default.series
+++ b/images/qemu-crinit-amd64/root/etc/crinit/default.series
@@ -1,4 +1,3 @@
 TASKDIR = /etc/crinit/crinit.d
 USE_SYSLOG = YES
 DEBUG = NO
-FILE_SIGS_NEEDED = NO


### PR DESCRIPTION
Remove not existing config option from the default.series. It does not exist and just causes warnings during boot.