### PR TITLE
added missing include for GNUInstallDirs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
 	"name": "EB corbos Linux SDK 1.3",
-	"image": "linux.elektrobit.com/ebcl/sdk:v1.3.8",
+	"image": "linux.elektrobit.com/ebcl/sdk:v1.3.9",
 	// This script will get the container and tag it with the local container tag. 
 	"initializeCommand": "${PWD}/init_workspace",
 	"postCreateCommand": "${PWD}/init_container",

--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # Version ID of the workspace template.
-export WS_VERSION="1.3.2"
+export WS_VERSION="1.3.3"
 # Log level for EBcL built tools.
 export LOG_LEVEL="INFO"
 # Copy SSH keys from host user.

--- a/apps/meminfo-reader/CMakeLists.txt
+++ b/apps/meminfo-reader/CMakeLists.txt
@@ -7,6 +7,9 @@ project(MeminfoReader)
 # Set the C standard to C99 (you can change this to C11 or another version if needed)
 set(CMAKE_C_STANDARD 99)
 
+# Include GNUInstallDirs to determine the correct values for CMAKE_INSTALL_*
+include(GNUInstallDirs)
+
 # Add the executable target
 add_executable(meminfo-reader meminfo_reader.c)
 

--- a/apps/my-json-app/CMakeLists.txt
+++ b/apps/my-json-app/CMakeLists.txt
@@ -4,6 +4,9 @@ project(MyJsonApp)
 
 set(CMAKE_CXX_STANDARD 11)
 
+# Include GNUInstallDirs to determine the correct values for CMAKE_INSTALL_*
+include(GNUInstallDirs)
+
 # Find the JSONCPP library
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(JSONCPP REQUIRED jsoncpp)


### PR DESCRIPTION

# Changes
Included GNUInstallDirs to fix install locations with CMAKE_INSTALL_<dir>

# Dependencies:
[fix cmake install prefix](https://github.com/Elektrobit/ebcl_dev_container/pull/16)


# Tests results

```bash
<!-- add Robot test CLI logs here. -->
```


# Developer Checklist:

- [ ] Test: Changes are tested
- [ ] Doc: Documentation has been updated 
- [ ] Git: Informative git commit message(s)
- [ ] Issue: If a related GitHub issue exists, linking is done

## Checklists for documentation

- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object

# Reviewer checklist:

- [x] Review: Changes are reviewed
- [x] Review: Tested by the reviewer

## Checklists for documentation

- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object

