### PR TITLE
Quality of life: use host network in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,9 @@
 	},
 	"remoteUser": "ebcl",
 	"privileged": true,
+	"runArgs": [
+		"--network=host"
+	],
 	"mounts": [
 		{
 			// Local storage for kiwi build VM images


### PR DESCRIPTION
# Changes

Add --network=host to make sure the package registries are reachable from inside the container.
This may depend on the users container setup, wsl / podman / docker, etc.

However, this makes live easier for me, and if does not hurt, lets add it by default,

# Dependencies:

none.

# Tests results

see checks.

# Developer Checklist:

- [x] Test: Changes are tested
- [x] Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- [x] Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:

- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
