### PR TITLE
Fix review findings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
 	"name": "EB corbos Linux SDK 1.4.0",
-	"image": "ghcr.io/elektrobit/ebcl_dev_container:v1.4.3",
+	"image": "ghcr.io/elektrobit/ebcl_dev_container:v1.4.4",
 	// This script will get the container and tag it with the local container tag. 
 	"initializeCommand": "${PWD}/init_workspace",
 	"postCreateCommand": "${PWD}/init_container",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
 	"name": "EB corbos Linux SDK 1.4.0",
-	"image": "ghcr.io/elektrobit/ebcl_dev_container:v1.4.1",
+	"image": "ghcr.io/elektrobit/ebcl_dev_container:v1.4.3",
 	// This script will get the container and tag it with the local container tag. 
 	"initializeCommand": "${PWD}/init_workspace",
 	"postCreateCommand": "${PWD}/init_container",

--- a/docs/examples/kernel.md
+++ b/docs/examples/kernel.md
@@ -13,8 +13,8 @@ We can get the kernel sources and build dependencies using apt:
 ```bash
 mkdir -p kernel
 cd kernel
-apt -y source linux-buildinfo-5.15.0-1034-s32-eb
-sudo apt -y build-dep linux-buildinfo-5.15.0-1034-s32-eb
+apt -y source linux-buildinfo-5.15.0-1034-s32-eb-optimized
+sudo apt -y build-dep linux-buildinfo-5.15.0-1034-s32-eb-optimized
 ```
 
 For extracting the kernel config, we can again make use of the _boot generator_:
@@ -81,7 +81,7 @@ We can add this to our _Makefile_ with the following changes:
 # Specification how to get the kernel config
 kernel_config = kernel_config.yaml
 # Kernel source package name
-kernel_package = linux-buildinfo-5.15.0-1034-s32-eb
+kernel_package = linux-buildinfo-5.15.0-1034-s32-eb-optimized
 
 #--------------------
 # Generated artifacts
@@ -96,7 +96,7 @@ kconfig = $(result_folder)/config
 # Kernel source
 source = kernel
 # Path of the kernel sources
-kernel_dir = $(source)/linux-s32-eb-5.15.0
+kernel_dir = $(source)/linux-s32-eb-optimized-5.15.0
 # Kernel make arguments
 kernel_make_args = ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
 

--- a/docs/examples/rdb2.md
+++ b/docs/examples/rdb2.md
@@ -12,7 +12,7 @@ arch: arm64
 use_ebcl_apt: true
 # Add repo with NXP RDB2 packages
 apt_repos:
-  - apt_repo: http://linux.elektrobit.com/eb-corbos-linux/1.2
+  - apt_repo: http://linux.elektrobit.com/eb-corbos-linux/1.4
     distro: ebcl_nxp_public
     components:
       - nxp_public

--- a/docs/examples/rdb2.md
+++ b/docs/examples/rdb2.md
@@ -5,7 +5,7 @@ The S32G2 has very specific storage layout requirements, and if you are interest
 
 ```yaml
 # Kernel package to use
-kernel: linux-image-unsigned-5.15.0-1034-s32-eb
+kernel: linux-image-unsigned-5.15.0-1034-s32-eb-optimized
 # CPU architecture
 arch: arm64
 # Add the EB corbos Linux apt repo

--- a/docs/images/from_scatch.md
+++ b/docs/images/from_scatch.md
@@ -80,7 +80,7 @@ You may notice that this image description requires three artifacts:
 - **ebcl_rdb2.config.tar**: This is a tarball containing the contents of our Linux root filesystem.
 
 Since the NXP S32G2 SoC is supported by EB corbos Linux, a FIP image and a kernel binary is provided as part of the releases and free download.
-The fip.s32 image is contained in the Debian package _arm-trusted-firmware-s32g_, and provided on https://linux.elektrobit.com/eb-corbos-linux/1.2 as part of the distribution _ebcl_nxp_public_ in the component _nxp_public_. The kernel binary and modules are provided by the same distro and component, packaged as _linux-image-unsigned-5.15.0-1023-s32-eb_, _linux-modules-5.15.0-1023-s32-eb_ and _linux-modules-extra-5.15.0-1023-s32-eb_. 
+The fip.s32 image is contained in the Debian package _arm-trusted-firmware-s32g_, and provided on https://linux.elektrobit.com/eb-corbos-linux/1.2 as part of the distribution _ebcl_nxp_public_ in the component _nxp_public_. The kernel binary and modules are provided by the same distro and component, packaged as _linux-image-unsigned-5.15.0-1034-s32-eb-optimized_, _linux-modules-5.15.0-1034-s32-eb-optimized_ and _linux-modules-extra-5.15.0-1034-s32-eb-optimized_. 
 
 The tooling to build the fitimage is contained in the packages _u-boot-s32-tools_, _arm-trusted-firmware-s32g_, _device-tree-compiler_, and  _nautilos-uboot-tools_. We need to install these tools in some environment to be able to build the fitimage.
 Adding them to the root filesystem would be a possibility, but not a good one, since this would bloat the root filesystem and also gives very useful tools to an attacker trying to hack our embedded solution.
@@ -91,7 +91,7 @@ Let’s first define some common settings used by our image overall, as _base.ya
 
 ```yaml
 # Kernel package to use
-kernel: linux-image-unsigned-5.15.0-1023-s32-eb
+kernel: linux-image-unsigned-5.15.0-1034-s32-eb-optimized
 # CPU architecture
 arch: arm64
 # Add the EB corbos Linux apt repo
@@ -107,7 +107,7 @@ apt_repos:
 
 ```
 
-This _base.yaml_ states that we want to use the kernel package _linux-image-unsigned-5.15.0-1023-s32-eb_, build an arm64 image, and make use of the default EBcL apt repository, and the EBcL NXP additions.
+This _base.yaml_ states that we want to use the kernel package _linux-image-unsigned-5.15.0-1034-s32-eb-optimized_, build an arm64 image, and make use of the default EBcL apt repository, and the EBcL NXP additions.
 Now we can base on this file and define our fitimage build environment as _boot_root.yaml_:
 
 ```yaml
@@ -117,9 +117,9 @@ base: base.yaml
 name: boot_root
 # Packages for boot_root.tar
 packages:
-  - linux-image-unsigned-5.15.0-1023-s32-eb
-  - linux-modules-5.15.0-1023-s32-eb
-  - linux-modules-extra-5.15.0-1023-s32-eb
+  - linux-image-unsigned-5.15.0-1034-s32-eb-optimized
+  - linux-modules-5.15.0-1034-s32-eb-optimized
+  - linux-modules-extra-5.15.0-1034-s32-eb-optimized
   - u-boot-s32-tools
   - arm-trusted-firmware-s32g
   - device-tree-compiler

--- a/docs/images/from_scatch.md
+++ b/docs/images/from_scatch.md
@@ -98,7 +98,7 @@ arch: arm64
 use_ebcl_apt: true
 # Add repo with NXP RDB2 packages
 apt_repos:
-  - apt_repo: http://linux.elektrobit.com/eb-corbos-linux/1.2
+  - apt_repo: http://linux.elektrobit.com/eb-corbos-linux/1.4
     distro: ebcl_nxp_public
     components:
       - nxp_public

--- a/images/amd64/appdev/qemu/crinit/config/etc/apt/sources.list
+++ b/images/amd64/appdev/qemu/crinit/config/etc/apt/sources.list
@@ -1,4 +1,4 @@
-deb http://linux.elektrobit.com/eb-corbos-linux/1.3 ebcl prod dev
+deb http://linux.elektrobit.com/eb-corbos-linux/1.4 ebcl prod dev
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main universe multiverse restricted
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-security main universe multiverse restricted
 deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main universe multiverse restricted

--- a/images/amd64/appdev/qemu/crinit/config_root.sh
+++ b/images/amd64/appdev/qemu/crinit/config_root.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Ensure init ie executable
+# Ensure init is executable
 chmod +x ./sbin/*
 
 # Create a fake machine-id

--- a/images/amd64/qemu/ebcl-server/crinit/config/etc/apt/sources.list
+++ b/images/amd64/qemu/ebcl-server/crinit/config/etc/apt/sources.list
@@ -1,4 +1,4 @@
-deb http://linux.elektrobit.com/eb-corbos-linux/1.3 ebcl prod dev
+deb http://linux.elektrobit.com/eb-corbos-linux/1.4 ebcl prod dev
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main universe multiverse restricted
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-security main universe multiverse restricted
 deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main universe multiverse restricted

--- a/images/amd64/qemu/ebcl-server/crinit/config/etc/crinit/crinit.d/earlysetup.crinit
+++ b/images/amd64/qemu/ebcl-server/crinit/config/etc/crinit/crinit.d/earlysetup.crinit
@@ -1,7 +1,7 @@
 # !LINKSTO ireq.config.hostname, 1
 NAME = earlysetup
 
-COMMAND = /usr/bin/hostname ebcl-server
+COMMAND = /usr/bin/hostname ebclserver
 
 PROVIDES = machine-id:wait
 RESPAWN = NO

--- a/images/amd64/qemu/ebcl/crinit/config_root.sh
+++ b/images/amd64/qemu/ebcl/crinit/config_root.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-# Link crinit as init
+# Ensure init is executable
 chmod +x /sbin/init

--- a/images/arm64/appdev/pi4/crinit/config_crinit.sh
+++ b/images/arm64/appdev/pi4/crinit/config_crinit.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# Ensure init is executable
 chmod +x ./sbin/init
 
 # Create a fake machine-id

--- a/images/arm64/appdev/pi4/crinit/crinit_config/etc/apt/sources.list
+++ b/images/arm64/appdev/pi4/crinit/crinit_config/etc/apt/sources.list
@@ -1,4 +1,4 @@
-deb http://linux.elektrobit.com/eb-corbos-linux/1.3 ebcl prod dev
+deb http://linux.elektrobit.com/eb-corbos-linux/1.4 ebcl prod dev
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main universe multiverse restricted
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-security main universe multiverse restricted
 deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main universe multiverse restricted

--- a/images/arm64/appdev/pi4/systemd/systemd_config/etc/apt/sources.list
+++ b/images/arm64/appdev/pi4/systemd/systemd_config/etc/apt/sources.list
@@ -1,4 +1,4 @@
-deb http://linux.elektrobit.com/eb-corbos-linux/1.3 ebcl prod dev
+deb http://linux.elektrobit.com/eb-corbos-linux/1.4 ebcl prod dev
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main universe multiverse restricted
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-security main universe multiverse restricted
 deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main universe multiverse restricted

--- a/images/arm64/appdev/qemu/crinit/config/etc/apt/sources.list
+++ b/images/arm64/appdev/qemu/crinit/config/etc/apt/sources.list
@@ -1,4 +1,4 @@
-deb http://linux.elektrobit.com/eb-corbos-linux/1.3 ebcl prod dev
+deb http://linux.elektrobit.com/eb-corbos-linux/1.4 ebcl prod dev
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main universe multiverse restricted
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-security main universe multiverse restricted
 deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main universe multiverse restricted

--- a/images/arm64/appdev/qemu/crinit/config_root.sh
+++ b/images/arm64/appdev/qemu/crinit/config_root.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Ensure init ie executable
+# Ensure init is executable
 chmod +x ./sbin/*
 
 # Create a fake machine-id

--- a/images/arm64/appdev/rdb2/base.yaml
+++ b/images/arm64/appdev/rdb2/base.yaml
@@ -1,12 +1,12 @@
 # Kernel package to use
-kernel: linux-buildinfo-5.15.0-1034-s32-eb
+kernel: linux-image-unsigned-5.15.0-1034-s32-eb-optimized
 # CPU architecture
 arch: arm64
 # Add the EB corbos Linux apt repo
 use_ebcl_apt: true
 # Add repo with NXP RDB2 packages
 apt_repos:
-  - apt_repo: http://linux.elektrobit.com/eb-corbos-linux/1.3
+  - apt_repo: http://linux.elektrobit.com/eb-corbos-linux/1.4
     distro: ebcl_nxp_public
     components:
       - nxp_public

--- a/images/arm64/appdev/rdb2/crinit/config_root.sh
+++ b/images/arm64/appdev/rdb2/crinit/config_root.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
-# Link crinit as init
+# Ensure init is executable
 chmod +x ./sbin/*
+
+# Ensure modprobe.sh is executable
+chmod +x ./usr/sbin/load_modules.sh
+chmod +x ./usr/sbin/ntp_time.sh
 
 # Create a fake machine-id
 echo "04711" > ./etc/machine-id

--- a/images/arm64/appdev/rdb2/systemd/systemd_config/etc/apt/sources.list
+++ b/images/arm64/appdev/rdb2/systemd/systemd_config/etc/apt/sources.list
@@ -1,4 +1,4 @@
-deb http://linux.elektrobit.com/eb-corbos-linux/1.3 ebcl prod dev
+deb http://linux.elektrobit.com/eb-corbos-linux/1.4 ebcl prod dev
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main universe multiverse restricted
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-security main universe multiverse restricted
 deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main universe multiverse restricted

--- a/images/arm64/nxp/rdb2/base.yaml
+++ b/images/arm64/nxp/rdb2/base.yaml
@@ -1,12 +1,12 @@
 # Kernel package to use
-kernel: linux-image-unsigned-5.15.0-1034-s32-eb
+kernel: linux-image-unsigned-5.15.0-1034-s32-eb-optimized
 # CPU architecture
 arch: arm64
 # Add the EB corbos Linux apt repo
 use_ebcl_apt: true
 # Add repo with NXP RDB2 packages
 apt_repos:
-  - apt_repo: http://linux.elektrobit.com/eb-corbos-linux/1.3
+  - apt_repo: http://linux.elektrobit.com/eb-corbos-linux/1.4
     distro: ebcl_nxp_public
     components:
       - nxp_public

--- a/images/arm64/nxp/rdb2/boot_root.yaml
+++ b/images/arm64/nxp/rdb2/boot_root.yaml
@@ -6,7 +6,7 @@ name: boot_root
 packages:
   - linux-image-unsigned-5.15.0-1034-s32-eb-optimized
   - linux-modules-5.15.0-1034-s32-eb-optimized
-  - linux-modules-extra-5.5.15.0-1034-s32-eb-optimized
+  - linux-modules-extra-5.15.0-1034-s32-eb-optimized
   - arm-trusted-firmware-s32
   - u-boot-s32-tools
   - device-tree-compiler

--- a/images/arm64/nxp/rdb2/boot_root.yaml
+++ b/images/arm64/nxp/rdb2/boot_root.yaml
@@ -4,9 +4,9 @@ base: base.yaml
 name: boot_root
 # Packages for boot_root.tar
 packages:
-  - linux-image-unsigned-5.15.0-1034-s32-eb
-  - linux-modules-5.15.0-1034-s32-eb
-  - linux-modules-extra-5.15.0-1034-s32-eb
+  - linux-image-unsigned-5.15.0-1034-s32-eb-optimized
+  - linux-modules-5.15.0-1034-s32-eb-optimized
+  - linux-modules-extra-5.5.15.0-1034-s32-eb-optimized
   - arm-trusted-firmware-s32
   - u-boot-s32-tools
   - device-tree-compiler

--- a/images/arm64/nxp/rdb2/crinit/config_root.sh
+++ b/images/arm64/nxp/rdb2/crinit/config_root.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-# Link crinit as init
+# Ensure init is executable
 chmod +x /sbin/init

--- a/images/arm64/nxp/rdb2/crinit/crinit_config/etc/crinit/crinit.d/earlysetup.crinit
+++ b/images/arm64/nxp/rdb2/crinit/crinit_config/etc/crinit/crinit.d/earlysetup.crinit
@@ -1,6 +1,6 @@
 NAME = earlysetup
 
-COMMAND = /bin/hostname qemucrinitvm
+COMMAND = /bin/hostname ebclrdb2
           
 PROVIDES = machine-id:wait
 RESPAWN = NO

--- a/images/arm64/nxp/rdb2/kernel_src/Makefile
+++ b/images/arm64/nxp/rdb2/kernel_src/Makefile
@@ -25,7 +25,7 @@ root_filesystem_spec = root.yaml
 # Specification how to get the kernel config
 kernel_config = kernel_config.yaml
 # Kernel source package name
-kernel_package = linux-buildinfo-5.15.0-1034-s32-eb
+kernel_package = linux-buildinfo-5.15.0-1034-s32-eb-optimized
 
 #-------------------------
 # Additional configuration
@@ -56,7 +56,7 @@ kconfig = $(result_folder)/config
 # Kernel source
 source = kernel
 # Path of the kernel sources
-kernel_dir = $(source)/linux-s32-eb-5.15.0
+kernel_dir = $(source)/linux-s32-eb-optimized-5.15.0
 # Kernel make arguments
 kernel_make_args = ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
 

--- a/images/arm64/nxp/rdb2/network/config_root.sh
+++ b/images/arm64/nxp/rdb2/network/config_root.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
-# Link crinit as init
+# Ensure init is executable
 chmod +x ./sbin/*
+
+# Ensure modprobe.sh is executable
+chmod +x ./usr/sbin/load_modules.sh
+chmod +x ./usr/sbin/ntp_time.sh
 
 # Create a fake machine-id
 echo "04711" > ./etc/machine-id

--- a/images/arm64/nxp/rdb2/systemd/server/config/etc/apt/sources.list
+++ b/images/arm64/nxp/rdb2/systemd/server/config/etc/apt/sources.list
@@ -1,4 +1,4 @@
-deb http://linux.elektrobit.com/eb-corbos-linux/1.3 ebcl prod dev
+deb http://linux.elektrobit.com/eb-corbos-linux/1.4 ebcl prod dev
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main universe multiverse restricted
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-security main universe multiverse restricted
 deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main universe multiverse restricted

--- a/images/arm64/qemu/ebcl/crinit/config_root.sh
+++ b/images/arm64/qemu/ebcl/crinit/config_root.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-# Link crinit as init
+# Ensure init is executable
 chmod +x /sbin/init

--- a/images/arm64/raspberry/pi4/crinit/config_crinit.sh
+++ b/images/arm64/raspberry/pi4/crinit/config_crinit.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# Ensure init is executable
 chmod +x ./sbin/init
 
 # Create a fake machine-id

--- a/images/arm64/raspberry/pi4/crinit/crinit_config/etc/apt/sources.list
+++ b/images/arm64/raspberry/pi4/crinit/crinit_config/etc/apt/sources.list
@@ -1,4 +1,4 @@
-deb http://linux.elektrobit.com/eb-corbos-linux/1.3 ebcl prod dev
+deb http://linux.elektrobit.com/eb-corbos-linux/1.4 ebcl prod dev
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main universe multiverse restricted
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-security main universe multiverse restricted
 deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main universe multiverse restricted

--- a/images/arm64/raspberry/pi4/systemd/systemd_config/etc/apt/sources.list
+++ b/images/arm64/raspberry/pi4/systemd/systemd_config/etc/apt/sources.list
@@ -1,4 +1,4 @@
-deb http://linux.elektrobit.com/eb-corbos-linux/1.3 ebcl prod dev
+deb http://linux.elektrobit.com/eb-corbos-linux/1.4 ebcl prod dev
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main universe multiverse restricted
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-security main universe multiverse restricted
 deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main universe multiverse restricted

--- a/images/example-old-images/qemu/berrymill/berrymill.conf
+++ b/images/example-old-images/qemu/berrymill/berrymill.conf
@@ -12,14 +12,14 @@ repos:
     # Conforms to Debian standard: https://wiki.debian.org/SupportedArchitectures
     arm64:
       EBcL:
-        url: http://linux.elektrobit.com/eb-corbos-linux/1.3
+        url: http://linux.elektrobit.com/eb-corbos-linux/1.4
         type: apt-deb
         key: file:///etc/berrymill/keyrings.d/elektrobit.gpg
         name: ebcl
         components: prod
       
       EBcL-Not-Supported:
-        url: http://linux.elektrobit.com/eb-corbos-linux/1.3
+        url: http://linux.elektrobit.com/eb-corbos-linux/1.4
         type: apt-deb
         key: file:///etc/berrymill/keyrings.d/elektrobit.gpg
         name: ebcl

--- a/images/example-old-images/qemu/berrymill/root/etc/apt/sources.list
+++ b/images/example-old-images/qemu/berrymill/root/etc/apt/sources.list
@@ -1,4 +1,4 @@
-deb http://linux.elektrobit.com/eb-corbos-linux/1.3 ebcl prod dev
+deb http://linux.elektrobit.com/eb-corbos-linux/1.4 ebcl prod dev
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main universe multiverse restricted
 deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-security main universe multiverse restricted
 deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main universe multiverse restricted


### PR DESCRIPTION
# Changes

- Fix comments
- Fix exec rights of modprobe.sh and other scripts
- Fix hostnames
- Make use of new RDB2 kernel

# Dependencies:

none

# Tests results

```bash
(venv) ebcl@e33ca934e2f8:/workspace/robot_tests$ robot images.robot 
==============================================================================
Images                                                                        
==============================================================================
Build Image amd64/qemu/jammy                                          | PASS |
------------------------------------------------------------------------------
Build Image amd64/qemu/ebcl/systemd                                   | PASS |
------------------------------------------------------------------------------
Build Image amd64/qemu/ebcl/crinit                                    | PASS |
------------------------------------------------------------------------------
Build Image amd64/qemu/ebcl-server/crinit                             | PASS |
------------------------------------------------------------------------------
Build Image amd64/qemu/ebcl-server/systemd                            | PASS |
------------------------------------------------------------------------------
Build Image arm64/qemu/jammy                                          | PASS |
------------------------------------------------------------------------------
Build Image arm64/qemu/ebcl/systemd                                   | PASS |
------------------------------------------------------------------------------
Build Image arm64/qemu/ebcl/crinit                                    | PASS |
------------------------------------------------------------------------------
Build Image arm64/nxp/rdb2/systemd                                    | PASS |
------------------------------------------------------------------------------
Build Image arm64/nxp/rdb2/crinit                                     | PASS |
------------------------------------------------------------------------------
Build Image arm64/nxp/rdb2/network                                    | PASS |
------------------------------------------------------------------------------
Build Image arm64/raspberry/pi4/crinit                                | PASS |
------------------------------------------------------------------------------
Build Image arm64/raspberry/pi4/systemd                               | PASS |
------------------------------------------------------------------------------
Build Image arm64/nxp/rdb2/systemd/server                             | PASS |
------------------------------------------------------------------------------
Build Image amd64/appdev/qemu/crinit                                  | PASS |
------------------------------------------------------------------------------
Build Image amd64/appdev/qemu/systemd                                 | PASS |
------------------------------------------------------------------------------
Build Image arm64/appdev/qemu/crinit                                  | PASS |
------------------------------------------------------------------------------
Build Image arm64/appdev/qemu/systemd                                 | PASS |
------------------------------------------------------------------------------
Build Image arm64/appdev/pi4/crinit                                   | PASS |
------------------------------------------------------------------------------
Build Image arm64/appdev/pi4/systemd                                  | PASS |
------------------------------------------------------------------------------
Build Image arm64/appdev/rdb2/crinit                                  | PASS |
------------------------------------------------------------------------------
Build Image arm64/appdev/rdb2/systemd                                 | PASS |
------------------------------------------------------------------------------
Build Image arm64/nxp/rdb2/kernel_src                                 | PASS |
------------------------------------------------------------------------------
Images                                                                | PASS |
23 tests, 23 passed, 0 failed
==============================================================================
Output:  /workspace/robot_tests/output.xml
Log:     /workspace/robot_tests/log.html
Report:  /workspace/robot_tests/report.html
```


# Developer Checklist:

- [x] Test: Changes are tested
- [x] Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- N/A Issue: If a related GitHub issue exists, linking is done

## Checklists for documentation

- N/A Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- N/A Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- N/A Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- N/A Terminology: technical terms are clear and they are used correctly and documented in the glossary
- N/A Level of detail: the content matches the detail level necessary for the reviewed object

# Reviewer checklist:

- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer

## Checklists for documentation

- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object

