### PR TITLE
fix sample application cmake prefix

### DIFF
--- a/apps/meminfo-reader/CMakePresets.json
+++ b/apps/meminfo-reader/CMakePresets.json
@@ -5,16 +5,46 @@
         "minor": 21
     },
     "include": [
-        "/build/cmake/BasePresets.json"
+        "/build/cmake/ebclPresets.json"
     ],
     "configurePresets": [
         {
-            "name": "base-app-env",
-            "inherits": "base",
-            "hidden": true,
+            "name": "qemu-x86_64",
+            "inherits": "ebcl-x86_64",
             "environment": {
                 "APP_NAME": "meminfo-reader"
             }
+        },
+        {
+            "name": "qemu-aarch64",
+            "inherits": "ebcl-aarch64",
+            "environment": {
+                "APP_NAME": "meminfo-reader"
+            }
+        },
+        {
+            "name": "hardware",
+            "inherits": "ebcl-aarch64",
+            "environment": {
+                "APP_NAME": "meminfo-reader"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "qemu-x86_64",
+            "configurePreset": "qemu-x86_64",
+            "inherits": "base"
+        },
+        {
+            "name": "qemu-aarch64",
+            "configurePreset": "qemu-aarch64",
+            "inherits": "base"
+        },
+        {
+            "name": "hardware",
+            "configurePreset": "hardware",
+            "inherits": "base"
         }
     ]
 }

--- a/apps/my-json-app/CMakePresets.json
+++ b/apps/my-json-app/CMakePresets.json
@@ -5,16 +5,46 @@
         "minor": 21
     },
     "include": [
-        "/build/cmake/BasePresets.json"
+        "/build/cmake/ebclPresets.json"
     ],
     "configurePresets": [
         {
-            "name": "base-app-env",
-            "inherits": "base",
-            "hidden": true,
+            "name": "qemu-x86_64",
+            "inherits": "ebcl-x86_64",
             "environment": {
                 "APP_NAME": "my-json-app"
             }
+        },
+        {
+            "name": "qemu-aarch64",
+            "inherits": "ebcl-aarch64",
+            "environment": {
+                "APP_NAME": "my-json-app"
+            }
+        },
+        {
+            "name": "hardware",
+            "inherits": "ebcl-aarch64",
+            "environment": {
+                "APP_NAME": "my-json-app"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "qemu-x86_64",
+            "configurePreset": "qemu-x86_64",
+            "inherits": "base"
+        },
+        {
+            "name": "qemu-aarch64",
+            "configurePreset": "qemu-aarch64",
+            "inherits": "base"
+        },
+        {
+            "name": "hardware",
+            "configurePreset": "hardware",
+            "inherits": "base"
         }
     ]
 }


### PR DESCRIPTION
The applications were not built in the correct path, because APP_NAME was not used because it was not in the inheritance chain anymore.

Fixes: 09e98103bf7da8b8a3f2007e86ba5dbc58a45a0b