### PR TITLE
Fix build-dep getting stuck when non interactive

### DIFF
--- a/images/arm64/nxp/rdb2/kernel_src/Makefile
+++ b/images/arm64/nxp/rdb2/kernel_src/Makefile
@@ -103,7 +103,7 @@ $(source):
 	@echo "Get kernel sources..."
 	mkdir -p $(source)
 	cd $(source) && apt -y source $(kernel_package)
-	sudo apt -y build-dep $(kernel_package)
+	sudo DEBIAN_FRONTEND=noninteractive apt-get -yq build-dep $(kernel_package)
 	cd $(kernel_dir) && chmod +x scripts/*.sh
 
 # Get the kernel config form the configured kernel binary package.


### PR DESCRIPTION
# Changes

Fix build-dep getting stuck when non interactive. Solves issue #70. 

# Dependencies:

none

# Tests results

```bash
<!-- add Robot test CLI logs here. -->
```

# Developer Checklist:

- [x] Test: Changes are tested
- [ ] Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- [x] Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:

- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
