### PR TITLE
Fix non-existing paths in documentation

### DIFF
--- a/docs/intro/arm64_host.md
+++ b/docs/intro/arm64_host.md
@@ -29,7 +29,7 @@ and select the "Reopen in container" command.
 
 Now you can build arm64 images.
 Open the folder containing the image description you want to build,
-e.g. _/workspace/images/arm64/qemu/ebcl/crinit/debootstrap_,
+e.g. _/workspace/images/arm64/qemu/ebcl/crinit_,
 in the integrated terminal in the dev container.
 Then run `make` to build the image.
 The build results are stored in a new created _build_ subfolder.
@@ -43,5 +43,5 @@ On Ubuntu, you can install it by running: `sudo apt install binfmt-support qemu 
 
 Then you can build the image in the same was as the arm64 images.
 Open the image folder in the terminal in the dev container,
-e.g. _/workspace/images/amd64/qemu/ebcl/crinit/debootstrap_.
+e.g. _/workspace/images/amd64/qemu/ebcl/crinit_.
 Then run the image build by executing `make` in the folder.


### PR DESCRIPTION
# Changes

Fixes example paths in documentation as the original paths did not exist.

# Dependencies:

# Tests results

```bash
<!-- add Robot test CLI logs here. -->
```


# Developer Checklist:

- [ ] Test: Changes are tested
- [x] Doc: Documentation has been updated 
- [ ] Git: Informative git commit message(s)
- [ ] Issue: If a related GitHub issue exists, linking is done

## Checklists for documentation

- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object

# Reviewer checklist:

- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer

## Checklists for documentation

- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object

