### PR TITLE
Build ebclfsa with clang and musl

### DIFF
--- a/apps/ebclfsa-demo/hi/hi_main.c
+++ b/apps/ebclfsa-demo/hi/hi_main.c
@@ -30,7 +30,7 @@ static void check_and_signal_watchdog(struct shmlib_watchdog* const watchdog,
     }
 }
 
-static int start_hi_forward_child(void*)
+static int start_hi_forward_child(void *arg __attribute__((unused)))
 {
     char* const argv[] = {NULL};
     char* const envp[] = {NULL};


### PR DESCRIPTION
ebclfsa-demo:
Utilize the CMake JSON configuration file to build the demo application with musl libraries, the Clang compiler, and the LLD linker.

ebclfsa-demo: 
The Clang compiler is stricter than GCC and raises errors for non-compliant source code. To successfully build the project, the source code of ebclfsa was slightly modified.