### PR TITLE
Update dev container to v1.4.11 for 1.x line

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
 	"name": "EB corbos Linux SDK 1.4.2",
-	"image": "ghcr.io/elektrobit/ebcl_dev_container:v1.4.5",
+	"image": "ghcr.io/elektrobit/ebcl_dev_container:v1.4.11",
 	// This script will get the container and tag it with the local container tag. 
 	"initializeCommand": "${PWD}/init_workspace",
 	"postCreateCommand": "${PWD}/init_container",

--- a/images/arm64/beaglebone/ai64/beaglebone.mk
+++ b/images/arm64/beaglebone/ai64/beaglebone.mk
@@ -171,6 +171,10 @@ root: $(base_tarball)
 .PHONY: initrd
 initrd: $(initrd_img)
 
+# build of the initrd.img(s)
+.PHONY: boot
+boot: $(boot_contents)
+
 # config the root tarball
 .PHONY: config
 config: $(root_tarball)

--- a/robot_tests/images.robot
+++ b/robot_tests/images.robot
@@ -82,11 +82,11 @@ Build Image arm64/nxp/rdb2/systemd/server
 #======================
 Build Image arm64/beaglebone/ai64/crinit
     [Tags]    arm64    ai64    hardware    debootstrap    ebcl    crinit    network
-    Test Systemd Image    arm64/beaglebone/ai64/crinit
+    Test Hardware Image    arm64/beaglebone/ai64/crinit
 
 Build Image arm64/beaglebone/ai64/systemd
     [Tags]    arm64    ai64    hardware    debootstrap    ebcl    systemd
-    Test Crinit Image    arm64/beaglebone/ai64/crinit
+    Test Hardware Image    arm64/beaglebone/ai64/crinit
 
 #========================
 # Tests for appdev images


### PR DESCRIPTION
# Changes

- Update dev container to v1.4.11.

# Dependencies:

none

# Tests results

```bash
(venv) ebcl@2fa57ecceb65:/workspace/robot_tests$ robot images.robot 
==============================================================================
Images                                                                        
==============================================================================
Build Image amd64/qemu/jammy                                          | PASS |
------------------------------------------------------------------------------
Build Image amd64/qemu/ebcl/systemd                                   | PASS |
------------------------------------------------------------------------------
Build Image amd64/qemu/ebcl/crinit                                    | PASS |
------------------------------------------------------------------------------
Build Image amd64/qemu/ebcl-server/crinit                             | PASS |
------------------------------------------------------------------------------
Build Image amd64/qemu/ebcl-server/systemd                            | PASS |
------------------------------------------------------------------------------
Build Image arm64/qemu/jammy                                          | PASS |
------------------------------------------------------------------------------
Build Image arm64/qemu/ebcl/systemd                                   | PASS |
------------------------------------------------------------------------------
Build Image arm64/qemu/ebcl/crinit                                    | PASS |
------------------------------------------------------------------------------
Build Image arm64/nxp/rdb2/systemd                                    | PASS |
------------------------------------------------------------------------------
Build Image arm64/nxp/rdb2/crinit                                     | PASS |
------------------------------------------------------------------------------
Build Image arm64/nxp/rdb2/network                                    | PASS |
------------------------------------------------------------------------------
Build Image arm64/raspberry/pi4/crinit                                | PASS |
------------------------------------------------------------------------------
Build Image arm64/raspberry/pi4/systemd                               | PASS |
------------------------------------------------------------------------------
Build Image arm64/nxp/rdb2/systemd/server                             | PASS |
------------------------------------------------------------------------------
Build Image arm64/beaglebone/ai64/crinit                              | FAIL |
'ERR: make: *** No rule to make target 'boot'.  Stop.

6e6afce9-544a-45f3-8eea-88795580230a

' does not contain 'Results were written to'
------------------------------------------------------------------------------
Build Image arm64/beaglebone/ai64/systemd                             | FAIL |
'ERR: make: *** No rule to make target 'boot'.  Stop.

8992e8f2-3b5f-41cf-bdf4-dc47bbd1675e

' does not contain 'Results were written to'
------------------------------------------------------------------------------
Build Image amd64/appdev/qemu/crinit                                  | PASS |
------------------------------------------------------------------------------
Build Image amd64/appdev/qemu/systemd                                 | PASS |
------------------------------------------------------------------------------
Build Image arm64/appdev/qemu/crinit                                  | PASS |
------------------------------------------------------------------------------
Build Image arm64/appdev/qemu/systemd                                 | PASS |
------------------------------------------------------------------------------
Build Image arm64/appdev/pi4/crinit                                   | PASS |
------------------------------------------------------------------------------
Build Image arm64/appdev/pi4/systemd                                  | PASS |
------------------------------------------------------------------------------
Build Image arm64/appdev/rdb2/crinit                                  | PASS |
------------------------------------------------------------------------------
Build Image arm64/appdev/rdb2/systemd                                 | PASS |
------------------------------------------------------------------------------
Build Image arm64/nxp/rdb2/kernel_src                                 | PASS |
------------------------------------------------------------------------------
Images                                                                | FAIL |
25 tests, 23 passed, 2 failed
==============================================================================
Output:  /workspace/robot_tests/output.xml
Log:     /workspace/robot_tests/log.html
Report:  /workspace/robot_tests/report.html
```

# Developer Checklist:

- [x] Test: Changes are tested
- [x] Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- N/A Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:

- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
