### PR TITLE
Fix bb ai64 image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
 	"name": "EB corbos Linux SDK 1.4.2",
-	"image": "ghcr.io/elektrobit/ebcl_dev_container:v1.4.5",
+	"image": "ghcr.io/elektrobit/ebcl_dev_container:v1.4.11",
 	// This script will get the container and tag it with the local container tag. 
 	"initializeCommand": "${PWD}/init_workspace",
 	"postCreateCommand": "${PWD}/init_container",

--- a/images/arm64/beaglebone/ai64/beaglebone.mk
+++ b/images/arm64/beaglebone/ai64/beaglebone.mk
@@ -171,6 +171,10 @@ root: $(base_tarball)
 .PHONY: initrd
 initrd: $(initrd_img)
 
+# build of the initrd.img(s)
+.PHONY: boot
+boot: $(boot_contents)
+
 # config the root tarball
 .PHONY: config
 config: $(root_tarball)

--- a/images/arm64/beaglebone/ai64/boot_configure.sh
+++ b/images/arm64/beaglebone/ai64/boot_configure.sh
@@ -6,15 +6,27 @@
 #       extlinux
 #          |------ extlinux.conf
 
+ls -lah
+ls -lah boot/
+ls -lah boot/dtbs/
+
+export KERNEL_VERSION=$(ls boot/dtbs/ | sort | tail -n 1)
+
+echo "Using kernel version: ${KERNEL_VERSION}"
+
 mkdir -p outdir/extlinux
 
 cp opt/u-boot/bb-u-boot-beagleboneai64/microsd-extlinux.conf outdir/extlinux/extlinux.conf
 sed -i 's:init=[^ ]*:init=/usr/bin/init:g' outdir/extlinux/extlinux.conf
-cp boot/dtbs/*/*/k3-j721e-sk.dtb outdir/
-cp boot/dtbs/*/*/k3-j721e-beagleboneai64.dtb outdir/
-cp boot/vmlinuz* outdir/Image.gz
+
+cp boot/dtbs/${KERNEL_VERSION}/*/k3-j721e-sk.dtb outdir/
+cp boot/dtbs/${KERNEL_VERSION}/*/k3-j721e-beagleboneai64.dtb outdir/
+
+cp boot/vmlinuz-${KERNEL_VERSION} outdir/
+mv outdir/vmlinuz* outdir/Image.gz
 gzip -d outdir/Image.gz
 
-cp -r boot/dtbs/*/*/overlays outdir/overlays
+mkdir -p outdir/overlays
 
-cp -r boot/dtbs/*/*/*.dtbo outdir/overlays
+cp -r boot/dtbs/${KERNEL_VERSION}/*/overlays outdir/
+cp -r boot/dtbs/${KERNEL_VERSION}/*/*.dtbo outdir/overlays

--- a/robot_tests/images.robot
+++ b/robot_tests/images.robot
@@ -82,11 +82,11 @@ Build Image arm64/nxp/rdb2/systemd/server
 #======================
 Build Image arm64/beaglebone/ai64/crinit
     [Tags]    arm64    ai64    hardware    debootstrap    ebcl    crinit    network
-    Test Systemd Image    arm64/beaglebone/ai64/crinit
+    Test Hardware Image    arm64/beaglebone/ai64/crinit
 
 Build Image arm64/beaglebone/ai64/systemd
     [Tags]    arm64    ai64    hardware    debootstrap    ebcl    systemd
-    Test Crinit Image    arm64/beaglebone/ai64/crinit
+    Test Hardware Image    arm64/beaglebone/ai64/crinit
 
 #========================
 # Tests for appdev images


### PR DESCRIPTION
# Changes

- Fix BB AI64 image build
- Fix BB AI64 robot tests

# Dependencies:

Tested with EBcL build tools v1.4.11.

# Tests results

```bash
(venv) ebcl@2fa57ecceb65:/workspace/robot_tests$ robot -i ai64 images.robot 
==============================================================================
Images                                                                        
==============================================================================
Build Image arm64/beaglebone/ai64/crinit                              | PASS |
------------------------------------------------------------------------------
Build Image arm64/beaglebone/ai64/systemd                             | PASS |
------------------------------------------------------------------------------
Images                                                                | PASS |
2 tests, 2 passed, 0 failed
==============================================================================
Output:  /workspace/robot_tests/output.xml
Log:     /workspace/robot_tests/log.html
Report:  /workspace/robot_tests/report.html
```


# Developer Checklist:

- [x] Test: Changes are tested
- N/A Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- N/A Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:

- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer

