### PR TITLE
Switch main_1.x tests to ubuntu-22.04

### DIFF
--- a/.github/workflows/robot-tests.yml
+++ b/.github/workflows/robot-tests.yml
@@ -38,7 +38,7 @@ jobs:
           echo "test_cases=$(./robot_tests/tools/extract_cases_names.py ./robot_tests/images.robot)" >> $GITHUB_OUTPUT
 
   Test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: prepare-sdk
     strategy:
       fail-fast: false

--- a/.github/workflows/robot-tests.yml
+++ b/.github/workflows/robot-tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   prepare-sdk:
     name: Prepare SDK for Robot Testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       # Names of every Test Case defined
       test_cases: ${{ steps.get_tests.outputs.test_cases }}


### PR DESCRIPTION
# Changes

As documented in the docs / setup. There is a bug on qemu-user-static in ubuntu 24.04. This leads to failures on arm64 builds.

Change main test workflow to ubuntu-22.04

# Dependencies:

no

# Tests results

see checks.

# Developer Checklist:

- [x] Test: Changes are tested
- [ ] Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- [ ] Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:

- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
