### PR TITLE
[EBLINUX-26382] Add simple robustness test

### DIFF
--- a/robustness_tests/run_make_qemu.py
+++ b/robustness_tests/run_make_qemu.py
@@ -1,0 +1,20 @@
+import subprocess
+import os
+
+# Define directory and build command
+directory = os.path.expanduser('../images/arm64/qemu/ebclfsa')
+command = 'make qemu'
+
+# Change to specified directory
+os.chdir(directory)
+
+# Run build command 10 times in a row
+for _ in range(10):
+    print(f"Running build {_+1}...")
+    result = subprocess.run(command, shell=True)
+
+    if result.returncode != 0:
+        print(f"Command failed with return code {result.returncode}")
+    else:
+        print("Command executed successfully")
+


### PR DESCRIPTION
# Changes

_Create `robustness_tests/run_make_qemu.py` that builds EBcLfSA demo for QEMU 10 times in a row_

# Dependencies:

_None_

# Tests results

```bash
$ cd robustness_tests
$ python3 run_make_qemu.py
Running build 1...
...
Running build 10...
Seems you hit a bug!
Please provide a bug ticket at https://github.com/Elektrobit/ebcl_build_tools/issues.You are using EBcl build tooling version 1.3.11,and EB corbos Linux workspace version None
[02/18/2025 06:12:42 PM] INFO   fake.py:43 - Running command: sudo bash -c "rm -f ~/.netrc"
[02/18/2025 06:12:42 PM] INFO   fake.py:43 - Running command: sudo bash -c "rm -rf /tmp/tmpec2gonxo"
make: *** [Makefile:186: build/hv_config/modules.list] Error 1
Command failed with return code 2
```

# Developer Checklist:

- [X] Test: Changes are tested
- [ ] Doc: Documentation has been updated 
- [X] Git: Informative git commit message(s)
- [X] Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:

- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
