### PR TITLE
Pin robot test workflows to ubuntu-22.04

### DIFF
--- a/.github/workflows/robot-tests.yml
+++ b/.github/workflows/robot-tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   prepare-sdk:
     name: Prepare SDK for Robot Testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       # Names of every Test Case defined
       test_cases: ${{ steps.get_tests.outputs.test_cases }}
@@ -39,7 +39,7 @@ jobs:
           echo "test_cases=$(./robot_tests/tools/extract_cases_names.py ./robot_tests/images.robot)" >> $GITHUB_OUTPUT
 
   Test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: prepare-sdk
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Changes

The automated robots tests are currently only working on ubuntu-22.04, and ubuntu-latest is a moving target (and 24.04 now).
In any case a versioned ubuntu version should be used for testing.

Tests for arm are failing due to the qemu-user-static version included in ubuntu-24.04.
This change fixes the runners to ubuntu-22.04 for now.

# Dependencies:

n/a

# Tests results

see checks

# Developer Checklist:

- [x] Test: Changes are tested
- [ ] Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- [ ] Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:

- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
