### PR TITLE
[EBLINUX-26382] Create robustness test with robot framework

### DIFF
--- a/robot_tests/robustness.robot
+++ b/robot_tests/robustness.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Resource    resources/image-build.robot
+Test Timeout    45m
+*** Test Cases ***
+
+#====================================
+# Test for QEMU ARM64 EBcLfSA image
+#====================================
+Build Image arm64/qemu/ebclfsa x10 times
+    
+    [Tags]    arm64    qemu    debootstrap    ebclfsa
+    FOR     ${index}    IN RANGE    10
+    Build Image    arm64/qemu/ebclfsa
+    END


### PR DESCRIPTION
# Changes

_Create `robot_tests/robustness.robot` that builds EBcLfSA image 10 times in a row_

# Dependencies:

_Uses `robot_tests/resources/image-build.robot`_


# Tests results

```bash
$ robot robustness.robot
==============================================================================
Robustness                                                                    
==============================================================================
Build Image arm64/qemu/ebclfsa x10 times                              | FAIL |
ProcessNotInitialized
------------------------------------------------------------------------------
Robustness                                                            | FAIL |
1 test, 0 passed, 1 failed
==============================================================================
Output:  /workspace/robot_tests/output.xml
Log:     /workspace/robot_tests/log.html
Report:  /workspace/robot_tests/report.html
```

The analysis of `output.xml` shows that `make clean` fails throwing a "ProcessNotInitialized". This needs to be investigated further (and perhaps shows a bug).

# Developer Checklist:

- [X] Test: Changes are tested
- [ ] Doc: Documentation has been updated 
- [X] Git: Informative git commit message(s)
- [X] Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:

- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
