### PR TITLE
 [sync from main_1.x] ebclfsa-demo: adjust code for Clang compiler

### DIFF
--- a/apps/ebclfsa-demo/hi/hi_main.c
+++ b/apps/ebclfsa-demo/hi/hi_main.c
@@ -30,7 +30,7 @@ static void check_and_signal_watchdog(struct shmlib_watchdog* const watchdog,
     }
 }
 
-static int start_hi_forward_child(void*)
+static int start_hi_forward_child(void *arg __attribute__((unused)))
 {
     char* const argv[] = {NULL};
     char* const envp[] = {NULL};


### PR DESCRIPTION
The Clang compiler is stricter than GCC and raises warnings for non-compliant source code. To successfully build the project, the source code of ebclfsa was slightly modified.

(cherry picked from commit 744be70bbf83c149f25f331ed3c7cfaf6f8bd33a)