### PR TITLE
add support for codespaces: install packages

### DIFF
--- a/init_workspace
+++ b/init_workspace
@@ -52,6 +52,15 @@ else
     echo "Not copying SSH keys from host."
 fi
 
+# Check if we are in a CODESPACES environment
+if [ "${CODESPACES}" = "true" ]; then
+    echo "CODESPACES environment detected."
+
+    echo "Installing package dependencies..."
+    sudo apt-get update -y
+    sudo apt-get install -y binfmt-support qemu-user-static
+fi
+
 echo ""
 echo "---------------------------------------------------------------------------"
 echo "Checking required tools on the development host"


### PR DESCRIPTION
# Changes

When starting the template in a github codespace, the packages checked in init_workspace prevent that.
This change adds automatic installation of those packages, when in a CODESPACE environment.

# Dependencies:

n/a

# Tests results

n/a

# Developer Checklist:

- [x] Test: Changes are tested
- [ ] Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- [ ] Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:

- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
