### PR TITLE
Fix/Update documentation

### DIFF
--- a/docs/apps/packaging.md
+++ b/docs/apps/packaging.md
@@ -18,7 +18,7 @@ to update them separately from the root image, a bundling according to the needs
 
 We don’t recommend apt as an update tool for embedded solutions, since it doesn’t support an A/B update schema, and it’s not prepared to be used together with a read-only and dm-verity protected root filesystem, which you may use if you implement a secure boot solution.
 For such scenarios, the existing embedded update solutions, and containers are much better solutions.
-If you need a customized update solution, or consulting for building online updateable HPC platforms, please [contact us](https://www.elektrobit.com/contact-us/).
+If you need a customized update solution, or consulting for building online updatable HPC platforms, please [contact us](https://www.elektrobit.com/contact-us/).
 
 ## Preparing the Debian package metadata
 

--- a/docs/examples/rpi.md
+++ b/docs/examples/rpi.md
@@ -32,7 +32,7 @@ apt_repos:
       - multiverse
       - restricted
   # Get Latest Community Tested Package Fixes
-  # This Repository is soley added for one reason:
+  # This Repository is solely added for one reason:
   # The flash-kernel postinstall script will try to execute
   # and write files to memory. This will not work in our build env (chroot).
   # flash-kernel will not do this on a system that is running in EFI Mode and
@@ -52,7 +52,7 @@ Please not that the EB corbos Linux APT repository is enabled in parallel to the
 This is in general possible, but the resulting image will contain the newer package versions form Ubuntu, 
 which are not qualified with the EB corbos Linux configuration and config and compatibility issues may happen.
 Please also be aware that _jammy-updates_ may provide upgraded libraries which are not supported with EB corbos Linux,
-since we only base on _jammy-secuirty_, to minimize the impact of the security maintenance to existing solutions.
+since we only base on _jammy-security_, to minimize the impact of the security maintenance to existing solutions.
 
 For booting, the Raspberry Pi expects to find a fat32 partition as first partition on the SD card,
 and this partition is expected to contain the firmware and kernel binaries and devicetrees,

--- a/docs/intro/dev_container.md
+++ b/docs/intro/dev_container.md
@@ -57,7 +57,7 @@ devcontainer exec --workspace-folder ./ebcl_template/ bash
 (venv) ebcl@25b055e27967:/workspace/images/amd64/appdev/qemu/ebcl_1.x_crinit$ task
 ```
 
-2. Ensure the ssh conection from your original decontainer session:
+2. Ensure the ssh connection from your original devcontainer session:
 
 ```
 TARGET=<preset> source /workspace/apps/common/deployment.targets && /workspace/apps/common/check_and_update_ssh_key.sh  --prefix "$SSH_PREFIX"  --port $SSH_PORT --user $SSH_USER --target $TARGET_IP
@@ -65,7 +65,7 @@ TARGET=<preset> source /workspace/apps/common/deployment.targets && /workspace/a
 
 Where `<preset>` is the one also used when building the to be deployed application.
 
-3. Deploy the application from your original decontainer session:
+3. Deploy the application from your original devcontainer session:
 
 ```
 TARGET=<preset> source /workspace/apps/common/deployment.targets && $SSH_PREFIX rsync -rlptv -e "ssh -p $SSH_PORT" --exclude */include/* --exclude *.debug /workspace/results/apps/<application>/qemu-aarch64/build/install/ $SSH_USER@[$TARGET_IP]:/

--- a/docs/intro/setup.md
+++ b/docs/intro/setup.md
@@ -88,7 +88,7 @@ This should install `qemu-aarch64` version 6.2.0.
 **WARNING**:
 When using a distribution that provides qemu in a version greater or equal to 8.1.1 (like Ubuntu 24.04) building for arm64 targets is broken due to a [bug](https://gitlab.com/qemu-project/qemu/-/issues/1913) in qemu. It will fail with a message like `W: Failure trying to run: chroot "/tmp/tmpp7s0kahl" /sbin/ldconfig`.
 We recommend either switching to Ubuntu 22.04 or downgrade qemu (and hold back updates).
-his can be done for example using:
+This can be done for example using:
 ```sh
 sudo apt remove qemu-user-static
 wget http://launchpadlibrarian.net/690251791/qemu-user-static_8.0.4+dfsg-1ubuntu3_amd64.deb
@@ -127,7 +127,7 @@ Now you can use the VS Code build tasks (_Ctrl_ + _Shift_ + _B_) to build the ex
 If you don’t want to use VS Code, or you want to integrate the EBcL SDK in your CI workflows, you can use the dev container stand-alone.
 For more details on how to do this, take a look at [dev container CLI](dev_container.md).
 
-### EBcL SDK setup customisation
+### EBcL SDK setup customization
 
 When the workspace container is initialized the file ~/.ebcl_config/.env from your host will be sourced.
 You can specify environment variables to customize the setup of the EBcL SDK.

--- a/docs/intro/setup.md
+++ b/docs/intro/setup.md
@@ -1,11 +1,5 @@
 # Setup
 
-<div class="warning">
-At the moment, the QEMU user mode package of Ubuntu 24.04 is partially broken.
-This issue causes arm64 deboostrap for Ubuntu 22.04 packages to segfault.
-Please use Ubuntu 22.04 to for building arm64 images.
-</div>
-
 The EB corbos Linux template workspace is tested using Ubuntu 22.04 and Ubuntu 24.04 host environments on x86_64 machines.
 It was verified once successfully that the container works also on [arm64 hosts](./arm64_host.md), but this variant is not covered by continuous testing.
 

--- a/docs/tests/performance.md
+++ b/docs/tests/performance.md
@@ -10,7 +10,7 @@ These images are assembled using a test overlay which is provided in a second pa
 and mounted in the early userspace,
 if the kernel cmdline parameter _test_overlay_, pointing to the partition, is provided.
 This is implemented for the _arm64/qemu/ebcl_ images.
-You can find the impementation in the
+You can find the implementation in the
 [init.sh.template](https://github.com/Elektrobit/ebcl_template/images/arm64/qemu/ebcl/init.sh.template).
 
 These test overlays provide a quite simple way to extend images with test extensions
@@ -18,11 +18,11 @@ in a very controlled manner, and make it easy to fully understand the impact of 
 test extensions. They may be also helpful for other kind of tests which require modified images.
 
 In general, we expect that also test extensions and manipulations are done during image build,
-and not during test execution time. If a test requires image manitpulations, a test specific
+and not during test execution time. If a test requires image manipulations, a test specific
 build target is created, which shall implement all changes in an easy to understand and
 reproducible way.
 This helps not only for the quality argumentation, but also helps in maintaining these modifications
-when the images change over time, reduces the requirements for the test exection environment,
+when the images change over time, reduces the requirements for the test execution environment,
 and allows to inspect the result of the manipulations.
 
 The [performance tests implemented in qemu_performance.robot](https://github.com/Elektrobit/ebcl_template/robot_tests/qemu_performance.robot)
@@ -40,7 +40,7 @@ and generates a test report.
 
 This approach doesn't allow for highly precise and stable performance numbers,
 since there is some variation and delay by reading the logs,
-but it's simple and portable and shoud provide numbers in a precision of
+but it is simple and portable and should provide numbers in a precision of
 a few 10 ms.
 From our point of view, it's good enough to get a first idea of image changes,
 and to setup some monitoring for performance degrades.

--- a/docs/tools/boot.md
+++ b/docs/tools/boot.md
@@ -28,7 +28,7 @@ The internal steps are:
 base: <base.yaml>
 kernel: as in base yaml, if build locally set to null
 tar: <true|false>
-use_packages:<true|false>
+use_packages: <true|false>
 # Name of the boot root archive, if given will be used as initial tarball base
 base_tarball: $$RESULTS$$/boot_root.tar
 # Files to copy form the host environment
@@ -41,5 +41,5 @@ files:
 # You can define multiple configuration scripts that will run "in" the tarball
 scripts:
   - name: <name.sh>
-    env: <chroot|chfake>
+    env: <chroot|fake|sudo|shell>
 ```

--- a/docs/tools/hypervisor.md
+++ b/docs/tools/hypervisor.md
@@ -17,3 +17,5 @@ A basic set of these files that should fit all versions of the hypervisor is del
 Additionally a directory containing specialization for the files can be passed to the hypervisor.
 This specialization should be bundled together with the hypervisor version used.
 It allows adding features to the configurator based on the hypervisor version used.
+
+See [Hypervisor config generator documentation](https://elektrobit.github.io/ebcl_build_tools/hypervisor_config.html) for details.

--- a/docs/tools/initrd.md
+++ b/docs/tools/initrd.md
@@ -44,7 +44,7 @@ modules_urls: [<module.deb>]
 # if none given busybox-static from mirrors defined in base.yaml will be used
 busybox_url: '<url.deb>'
 # If not using the kernel meta-package specify a concrete version
-kversion: <version>
+kernel_version: <version>
 # Root device to mount
 root_device: dev/<root_device>
 # devices to be available in init, type can be block ot char

--- a/docs/tools/root_config.md
+++ b/docs/tools/root_config.md
@@ -26,6 +26,6 @@ The internal steps are:
 # You can define multiple configuration scripts that will run "in" the tarball
 scripts:
   - name: <name.sh>
-    env: <chroot|chfake>
+    env: <chroot|fake|sudo|shell>
   - name: ...
 ```

--- a/ebcl_sdk.code-workspace
+++ b/ebcl_sdk.code-workspace
@@ -22,6 +22,7 @@
 	"settings": {
 		"git.ignoreLimitWarning": true,
 		"cSpell.words": [
+			"Autosar",
 			"BINDIR",
 			"bootargs",
 			"buildinfo",
@@ -37,6 +38,7 @@
 			"devicetrees",
 			"devpts",
 			"ebcl",
+			"Elektrobit",
 			"embdgen",
 			"fakechroot",
 			"fakeedit",

--- a/robot_tests/data/initrd.yaml
+++ b/robot_tests/data/initrd.yaml
@@ -32,4 +32,3 @@ files:
     mode: 777
     uid: 123
     gid: 456
-kversion: 5.15.0-1023-s32-eb


### PR DESCRIPTION
Fix some typos in the docs, apart from that:

 * remove/replace references to "kversion" config parameter. It does not exist and is "kernel_version"
 * remove the duplicate warning for qemu in ubuntu 24.04 at the top of setup.md
 * add link to hypervisor config generator documentation