### PR TITLE
QEMU binfmt support check independent of location

### DIFF
--- a/init_workspace
+++ b/init_workspace
@@ -60,7 +60,7 @@ echo "--------------------------------------------------------------------------
 ARCH=$(uname -m)
 if [ "$ARCH" = "aarch64" ] ||  [ "$ARCH" = "arm64" ]; then
     echo "ARM platform detected. No QEMU binfmt support is required."
-elif [ -e /proc/sys/fs/binfmt_misc/qemu-aarch64 ] && [ -e /usr/bin/qemu-aarch64-static ]; then
+elif [ -e /proc/sys/fs/binfmt_misc/qemu-aarch64 ] && which qemu-aarch64-static; then
     echo "QEMU binfmt support is already enabled."
 else
     echo "Error: QEMU binfmt support is missing. Please install the required packages and try again."

--- a/init_workspace
+++ b/init_workspace
@@ -60,7 +60,7 @@ echo "--------------------------------------------------------------------------
 ARCH=$(uname -m)
 if [ "$ARCH" = "aarch64" ] ||  [ "$ARCH" = "arm64" ]; then
     echo "ARM platform detected. No QEMU binfmt support is required."
-elif [ -e /proc/sys/fs/binfmt_misc/qemu-aarch64 ] && which qemu-aarch64-static; then
+elif [ -e /proc/sys/fs/binfmt_misc/qemu-aarch64 ] && which qemu-aarch64-static > /dev/null; then
     echo "QEMU binfmt support is already enabled."
 else
     echo "Error: QEMU binfmt support is missing. Please install the required packages and try again."


### PR DESCRIPTION
 Use which to be independent of installed location of qemu-aarch64-static as this was an issue on WSL noble combinations

# Tests results
na


# Developer Checklist:

- [x] Test: Changes are tested
- [x] Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- [x] Issue: If a related GitHub issue exists, linking is done

## Checklists for documentation

- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object

# Reviewer checklist:

- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer

## Checklists for documentation

- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object

