### PR TITLE
vscode: disable keybinds in terminal

### DIFF
--- a/ebcl_sdk.code-workspace
+++ b/ebcl_sdk.code-workspace
@@ -80,7 +80,8 @@
 			"veritysetup",
 			"virt",
 			"virtio"
-		]
+		],
+		"terminal.integrated.sendKeybindingsToShell": true
 	},
 	"launch": {
 		"version": "0.2.0",


### PR DESCRIPTION
When working with qemu and especially the hypervisor in the terminal, key sequences like CTRL+E are required. Most sequences have keybinds in vscode, that are interpreted even in a terminal.
This option disables the keybinds, while the focus is in the terminal, so these sequences can be sent to the terminal

(cherry picked from commit 12b60416d1ee0bd5b787ca9c8c73193afbd2d890)
