### PR TITLE
vscode: make terminal default to interactive shell

### DIFF
--- a/ebcl_sdk.code-workspace
+++ b/ebcl_sdk.code-workspace
@@ -81,7 +81,13 @@
 			"virt",
 			"virtio"
 		],
-		"terminal.integrated.sendKeybindingsToShell": true
+		"terminal.integrated.sendKeybindingsToShell": true,
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "/bin/bash",
+				"args": [ "-l" ]
+			},
+		}
 	},
 	"launch": {
 		"version": "0.2.0",


### PR DESCRIPTION
# Changes

Starting bash with the -l parameter starts it in interactive shell mode, which sources /etc/profile. This is required to load for example bash-completions, when they are installed.

# Dependencies:

This only makes a real difference after Elektrobit/ebcl_dev_container#56 is merged and integrated into the workspace.
With these two changes full bash completion is working (i.e. git checkout <TAB> or task <TAB>)